### PR TITLE
Release/0.2.0

### DIFF
--- a/commands/package.js
+++ b/commands/package.js
@@ -54,15 +54,15 @@ module.exports = async (src, dist, platform, architecture) => {
 	// Package app according with platform
 	if (platform == 'win32') {
 		// Create windows installer
-		packageWindowsInstaller(src, dist, outputFolder, outputInstallerName)
+		await packageWindowsInstaller(src, dist, outputFolder, outputInstallerName)
 	}
 	if (platform == 'darwin') {
 		// Create macos dmg
-		packageDarwinDmg(src, outputInstallerPath)
+		await packageDarwinDmg(src, outputInstallerPath)
 	}
 	if (platform == 'linux') {
 		// Zip bundled app to distribute
-		packageLinux(src, outputInstallerPath)
+		await packageLinux(src, outputInstallerPath)
 	}
 
 	// Compress source code

--- a/commands/sign-darwin.js
+++ b/commands/sign-darwin.js
@@ -1,0 +1,3 @@
+module.exports = async (file) => {
+	console.log('signing for OSX')
+}

--- a/commands/sign-win32.js
+++ b/commands/sign-win32.js
@@ -1,0 +1,18 @@
+const execute = require('../utils/execute')
+
+const runSignTool = async (file) => {
+	return new Promise((resolve, reject) => {
+		execute(async ({ exec }) => {
+			try {
+				await exec(`signtool sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a ${file}`)
+				resolve()
+			} catch (err) {
+				reject(err)
+			}
+		})
+	})
+}
+
+module.exports = async (file) => {
+	await runSignTool(file)
+}

--- a/commands/sign.js
+++ b/commands/sign.js
@@ -1,3 +1,10 @@
-module.exports = async (file, config) => {
-	console.log('signing', file, config)
+module.exports = async (file, platform) => {
+	console.log('signing', file, 'for', platform)
+	if (platform === 'win32') {
+		const signWindows = require('./sign-win32.js')
+		await signWindows(file)
+	} else if (platform === 'darwin') {
+		const signDarwin = require('./sign-darwin.js')
+		await signDarwin(file)
+	}
 }

--- a/desktop-packager-sign.js
+++ b/desktop-packager-sign.js
@@ -5,11 +5,11 @@ const sign = require('./commands/sign')
 
 program
 	.option('-f, --file <file>', 'file to sign')
-	.option('-c, --config <file>', 'signing configuration file')
+	.option('-p, --platform <platform>', 'which platform to sign (win32 or darwin)')
 
 program.parse(process.argv)
 
 const FILE = program.file
-const CONFIG = program.config
+const PLATFORM = program.platform || process.platform
 
-sign(path.resolve(FILE), path.resolve(CONFIG))
+sign(path.resolve(FILE), PLATFORM)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@strawbees/desktop-packager",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "Command line tool to automate the building, packaging and deploying of Strawbees desktop apps",
     "main": "desktop-packager.js",
     "scripts": {


### PR DESCRIPTION
Implements `destkop-packager-sign` (and its alias `desktop-packger sign`) for Windows.

It requires a `-f, --file` argument pointing to which file to sign and an optional `-p, --platform` argument flagging which signing process to use (`win32` or `darwin`). Platform defaults to the current platform found on `process.platform` on nodejs.