### PR TITLE
Release/0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@strawbees/desktop-packager",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@strawbees/desktop-packager",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@strawbees/desktop-packager",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "Command line tool to automate the building, packaging and deploying of Strawbees desktop apps",
     "main": "desktop-packager.js",
     "scripts": {

--- a/utils/download.js
+++ b/utils/download.js
@@ -3,14 +3,21 @@ const request = require('request')
 
 module.exports = async (url, path) => {
 	await new Promise((resolve, reject) => {
+		let file = fs.createWriteStream(path)
+		file.on('finish', () => {
+			file.close(async (err) => {
+				if (err) {
+					await fs.promises.unlink(path)
+					return reject(err)
+				}
+				return resolve()
+			})
+		})
 		request.get(url)
 			.on('error', async (err) => {
 				await fs.promises.unlink(path)
 				reject(err)
 			})
-			.on('response', async (response) => {
-				resolve()
-			})
-			.pipe(fs.createWriteStream(path))
+			.pipe(file)
 	})
 }


### PR DESCRIPTION
The `download` promise was being resolved before the file was completely written on the disk. The `unzip` would fail and the application icon wouldn't be changed.

This is a regression bug solved by bringing the solution from the previous implementation: Wait until the stream is finished, close the file and resolve the promise.