### PR TITLE
Precalculate the installation size

### DIFF
--- a/assets/win32/installer.template.nsi
+++ b/assets/win32/installer.template.nsi
@@ -17,6 +17,7 @@ ManifestDPIAware true
 !define SOURCE_PATH "{{SOURCE_PATH}}"
 !define APP_EXECUTABLE_NAME "{{APP_EXECUTABLE_NAME}}"
 !define APP_URL_SCHEME "{{APP_URL_SCHEME}}"
+!define APP_SIZE "{{APP_SIZE}}"
 !define DRIVER_INSTALLER "{{DRIVER_INSTALLER}}"
 
 Name "${APP_NAME} ${APP_VERSION}"
@@ -196,8 +197,7 @@ FunctionEnd
 
 Function .onInit
 	SetOutPath $INSTDIR
-	${GetSize} "${SOURCE_PATH}" "/S=0K" $0 $1 $2
-	SectionSetSize ${AppCode} $0
+	SectionSetSize ${AppCode} ${APP_SIZE}
 	SectionSetSize ${QuirkbotDrivers} 15
 FunctionEnd
 

--- a/commands/package-win32.js
+++ b/commands/package-win32.js
@@ -17,6 +17,11 @@ const downloadDriver = async (url, filename) => {
 	await download(url, path.resolve(driverFolderPath, filename))
 }
 
+const calculateInstallationSize = async (src) => {
+	const fileStatus = await fs.stat(src) // in bytes
+	return fileStatus.size / 1000.0 // in Kilobytes
+}
+
 const bakeNsiFile = async (appPkg, src) => {
 	let driverInstaller = appPkg.driver ? appPkg.driver.filename : ''
 	const template = (await fs.readFile(nsiTemplatePath)).toString()
@@ -25,6 +30,7 @@ const bakeNsiFile = async (appPkg, src) => {
 		.split('{{APP_VERSION}}').join(appPkg.version)
 		.split('{{APP_PUBLISHER}}').join(appPkg.publisher)
 		.split('{{APP_URL_SCHEME}}').join(appPkg['url-scheme'])
+		.split('{{APP_SIZE}}').join(calculateInstallationSize(src))
 		.split('{{SOURCE_PATH}}').join(src)
 		.split('{{TEMP_BUILD_PATH}}').join(assetsFolder)
 		.split('{{DRIVER_INSTALLER}}').join(driverInstaller)


### PR DESCRIPTION
The command to calculate the installation size, `GetSize`, calculates dynamically. Since the source folder does not exist yet during installation it will always return `0Kb`. Therefore this size must be calculated before packaging the app and baked into the `NSIS` config file.