### PR TITLE
Fix folder permissions on MacOS bundle process

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ codesign --force --verify --verbose --sign  "$IDENTITY" ./dist/bundle/Strawbees 
 
 First of all you must follow the instructions to download the necessary certifications and add to your keychain. Check the documentation for that on [Apple's Developer Account Help](https://help.apple.com/developer-account/#/deveedc0daa0).
 
-You'll need to create a `macOS` certificate of type `Production: Developer ID` and for both `Developer ID Application` and `Developer ID Installer` (two different certificates).
+You'll need to create a `macOS` certificate of type `Production: Developer ID` for both `Developer ID Application`.
 
 Once you selected it, follow the instructions to create a `CSR` file and upload it to the website.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -312,6 +312,11 @@
                 "supports-color": "^2.0.0"
             }
         },
+        "chmodr": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.2.0.tgz",
+            "integrity": "sha512-Y5uI7Iq/Az6HgJEL6pdw7THVd7jbVOTPwsmcPOBjQL8e3N+pz872kzK5QxYGEy21iRys+iHWV0UZQXDFJo1hyA=="
+        },
         "chownr": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@strawbees/desktop-packager",
-    "version": "0.5.1",
+    "version": "0.5.3",
     "description": "Command line tool to automate the building, packaging and deploying of Strawbees desktop apps",
     "main": "desktop-packager.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dependencies": {
         "adm-zip": "^0.4.13",
         "archiver": "^3.0.0",
+        "chmodr": "^1.2.0",
         "commander": "^2.19.0",
         "nwjs-builder": "^1.14.0",
         "request": "^2.88.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@strawbees/desktop-packager",
-    "version": "0.5.2",
+    "version": "0.5.1",
     "description": "Command line tool to automate the building, packaging and deploying of Strawbees desktop apps",
     "main": "desktop-packager.js",
     "scripts": {

--- a/utils/chmod.js
+++ b/utils/chmod.js
@@ -1,0 +1,13 @@
+const chmodr = require('chmodr')
+
+module.exports = async (path, perm) => {
+  return new Promise((resolve, reject) => {
+    chmodr(path, perm, (err) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve()
+      }
+    })
+  })
+}


### PR DESCRIPTION
When administrator user installs Strawbees CODE on "global" Application folder, other users see an empty NWJS app window when they open it.

This is due to the bundling process making a temporary folder that gives the user full access but no access to "Everyone".

This PR adds a step in the MacOS bundle process that changes the permission of the folder `Strawbees CODE.app/Contents/Resources/app.nw/` to `755`.